### PR TITLE
Allow connection to a local database

### DIFF
--- a/src/Modl/Modl.php
+++ b/src/Modl/Modl.php
@@ -135,7 +135,7 @@ class Modl
             }
 
             $this->_db = new \PDO(
-                $this->_dbtype.':host='.$this->_host.';dbname='.$this->_database.';port='.$this->_port,
+                $this->dsn(),
                 $this->_username,
                 $this->_password,
                 $params
@@ -147,6 +147,25 @@ class Modl
             Utils::log($e->getMessage());
             die();
         }
+    }
+
+    protected function dsn()
+    {
+        $dsn = $this->_dbtype.':';
+
+        if($this->_host) {
+          $dsn .= 'host='.$this->_host;
+        }
+
+        if($this->_database) {
+          $dsn .= ';dbname='.$this->_database;
+        }
+
+        if($this->_port) {
+          $dsn .= ';port='.$this->_port;
+        }
+
+        return $dsn;
     }
 
     protected function inject()


### PR DESCRIPTION
Sometimes you don't have an INET socket open, and you just want to use
the default local unix socket for your database.  This allows you to
omit un-needed host/port configuration and have it work.